### PR TITLE
fixed basePath and filename contains slash

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ var Gry = require("gry")
 
 // Constants
 const PATH_LIBS = "/ajax/libs/"
-    , PATH_DIST = ["/dist", "/build", "/src", "/"]
+    , PATH_DIST = ["dist", "build", "src", ""]
     , PATH_PACK = "package.json"
     ;
 
@@ -152,7 +152,7 @@ CdnJsImporter.prototype.add = function (lib, callback) {
             // Detect the cdn files
             if (!lib.dir) {
                 for (; i < PATH_DIST.length; ++i) {
-                    cDir = path + PATH_DIST[i];
+                    cDir = path + "/" + PATH_DIST[i];
                     if (IsThere(cDir)) {
                         srcDir = cDir;
                         lib.dir = PATH_DIST[i]
@@ -208,7 +208,7 @@ CdnJsImporter.prototype.add = function (lib, callback) {
                 delete package.devDependencies;
 
                 // Append the filename field used by cdnjs
-                package.filename = files[0].replace(pwd, "");
+                package.filename = files[0].replace(pwd + "/" , "");
 
                 temp = package.filename.split(".");
                 ext = temp.pop();


### PR DESCRIPTION
This PR to fix `basePath` and `filename` in package.json will contain "/".
