### PR TITLE
Change commit language to use imperative mood

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -283,7 +283,7 @@ CdnJsImporter.prototype.add = function (lib, callback) {
         // Commit the changes
       , function (cb) {
             Logger.log("Committing the changes", "info");
-            var message = "Added " + package.name + "@" + package.version;
+            var message = "Add " + package.name + "@" + package.version;
             self.git.commit(message, function (err) {
                 if (err) {
                     Logger.log("Failed to commit the changes: " + err.toString(), "error");


### PR DESCRIPTION
@PeterDaveHello I've noticed you changed name of one of my PRs to use imperative mood.

I agree it's [a better practice](http://chris.beams.io/posts/git-commit/#imperative). It also aligns with how all the other commits are currently named in cdnjs.